### PR TITLE
Add Caddyfile configuration and Nixpacks setup for Angular app

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,37 @@
+# global options
+{
+	admin off # theres no need for the admin api in railway's environment
+	persist_config off # storage isn't persistent anyway
+	auto_https off # railway handles https for us, this would cause issues if left enabled
+	# runtime logs
+	log {
+		format json # set runtime log format to json mode 
+	}
+	# server options
+	servers {
+		trusted_proxies static private_ranges # trust railway's proxy
+	}
+}
+
+# site block, listens on the $PORT environment variable, automatically assigned by railway
+:{$PORT} {
+	# access logs
+	log {
+		format json # set access log format to json mode
+	}
+
+	# health check for railway
+	rewrite /health /*
+
+	# serve from the set folder
+	root * {$ANGULAR_OUTPUT_PATH}/browser
+
+	# enable gzipping responses
+	encode gzip
+
+	# serve files
+	file_server
+
+	# if path doesn't exist, redirect it to 'index.html' for client side routing
+	try_files {path} /index.html
+}

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,0 +1,25 @@
+# https://nixpacks.com/docs/configuration/file
+
+# set up some variables to minimize annoyance
+[variables]
+    NPM_CONFIG_UPDATE_NOTIFIER = 'false' # the update notification is relatively useless in a production environment
+    NPM_CONFIG_FUND = 'false' # the fund notification is also pretty useless in a production environment
+
+# setup phase where we add any needed packages
+[phases.setup]
+    nixPkgs = ['...', 'jq'] # jq is needed to parse the outputPath from our angular.json file
+
+# download caddy from nix
+[phases.caddy]
+    dependsOn = ['setup'] # make sure this phase runs after the default 'setup' phase
+    nixpkgsArchive = 'ba913eda2df8eb72147259189d55932012df6301' # Caddy v2.8.4 - https://github.com/NixOS/nixpkgs/commit/ba913eda2df8eb72147259189d55932012df6301
+    nixPkgs = ['caddy'] # install caddy as a nix package
+
+# format the Caddyfile with fmt
+[phases.fmt]
+    dependsOn = ['caddy'] # make sure this phase runs after the 'caddy' phase so that we know we have caddy downloaded
+    cmds = ['caddy fmt --overwrite Caddyfile'] # format the Caddyfile to fix any formatting inconsistencies
+
+# compute the output path and start the caddy web server
+[start]
+    cmd = 'export ANGULAR_OUTPUT_PATH=$(jq -r "[.projects[] | .architect.build.options.outputPath][0]" angular.json) && exec caddy run --config Caddyfile --adapter caddyfile 2>&1' # load the contents of the output file into a variable and start caddy using the Caddyfile config and caddyfile adapter


### PR DESCRIPTION
Introduce a Caddyfile for serving the Angular application and configure Nixpacks to streamline the build and deployment process. This setup includes necessary environment variables, package installations, and commands to run the Caddy web server.